### PR TITLE
Add Code of Conduct and update project metadata links

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,8 @@ time, so it works with *any* pybtex formatting style, including third-party ones
 ## Development
 
 For information on how to set up the development environment, run tests, and contribute to the project, please see
-[CONTRIBUTING.md](CONTRIBUTING.md).
+[CONTRIBUTING.md](docs/contributing.md).
+
+All participants are expected to follow the [Code of Conduct](docs/code_of_conduct.md).
+
+See the [Security Policy](docs/security.md) for information on how to report vulnerabilities.

--- a/docs/code_of_conduct.md
+++ b/docs/code_of_conduct.md
@@ -1,0 +1,87 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all. We are committed to fostering an environment
+that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics
+including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender,
+gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin,
+socio-economic position, level of education, or other status. The same privileges of participation are extended to
+everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive
+behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture,
+background, or native language. With these considerations in mind, we agree to behave mindfully toward each other and
+act in ways that center our shared values, including:
+
+- Respecting the purpose of our community, our activities, and our ways of gathering.
+- Engaging kindly and honestly with others.
+- Respecting different viewpoints and experiences.
+- Taking responsibility for our actions and contributions.
+- Gracefully giving and accepting constructive feedback.
+- Committing to repairing harm when it occurs.
+- Behaving in other ways that promote and sustain the well-being of our community.
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are
+violations of this Code of Conduct.
+
+- **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any
+  clear request to stop.
+- **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of
+  people.
+- **Stereotyping or discrimination.** Characterizing anyone's personality or behavior on the basis of immutable
+  identities or traits.
+- **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or
+  purpose of the community.
+- **Violating confidentiality.** Sharing or acting on someone's personal or private information without their
+  permission.
+- **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+- **Behaving in other ways that threaten the well-being of our community.**
+
+### Other Restrictions
+
+- **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade
+  enforcement actions.
+- **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+- **Promotional materials.** Sharing marketing or other commercial content in a way that is outside the norms of the
+  community.
+- **Irresponsible communication.** Failing to responsibly present content which includes, links, or describes any other
+  restricted behaviors.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict
+represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help
+avoid conflicts and minimize harm. When an incident does occur, it is important to report it promptly.
+
+To report a possible violation, please contact [nikomsavola@gmail.com](mailto:nikomsavola@gmail.com). Community
+Moderators take reports of violations seriously and will make every effort to respond in a timely manner.
+
+## Addressing and Repairing Harm
+
+In order to honor these values, enforcement actions are carried out in private with the involved parties, but
+communicating to the whole community may be part of a mutually agreed upon resolution.
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, they may take any
+action they deem appropriate, up to and including a temporary or permanent ban from the community.
+
+Our goal is to address and repair harm, and to find ways to safely reintegrate someone back into the community after an
+incident occurs. This may include:
+
+- A private conversation to discuss the behavior and its impact.
+- A public or private apology.
+- A temporary or permanent ban from certain community spaces or activities.
+- A temporary or permanent ban from the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at
+[https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy
+of this license, visit
+[https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,5 +51,6 @@ api
 :caption: Project
 
 contributing
+code_of_conduct
 security
 ```


### PR DESCRIPTION
This PR adds a Code of Conduct to the project, based on the Contributor Covenant 3.0.

### Changes
- Created docs/code_of_conduct.md.
- Updated README.md with links to the Code of Conduct and Security Policy.
- Fixed the link to the contributing guidelines in README.md.
- Included the Code of Conduct in the documentation index (docs/index.md).