### PR TITLE
Fix typo in update-pre recipe and update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         additional_dependencies:
           - tomli
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.15.9
     hooks:
       - id: ruff
         priority: 10
@@ -54,7 +54,7 @@ repos:
       - id: zizmor
         priority: 10
   - repo: https://github.com/facebook/pyrefly-pre-commit
-    rev: 0.58.0
+    rev: 0.60.0
     hooks:
       - id: pyrefly-check
         priority: 20
@@ -92,7 +92,7 @@ repos:
           - mdformat-frontmatter
           - mdformat-footnote
   - repo: https://github.com/tombi-toml/tombi-pre-commit
-    rev: v0.9.12
+    rev: v0.9.16
     hooks:
       - id: tombi-format
         priority: 10

--- a/justfile
+++ b/justfile
@@ -23,7 +23,7 @@ clean:
 # Update pre-commit hooks to the latest revisions
 [group('lint')]
 update-pre:
-    @uvx prek autupdate -j $(( {{ cpus }} / 2 + {{ cpus }} % 2 ))
+    @uvx prek autoupdate -j $(( {{ cpus }} / 2 + {{ cpus }} % 2 ))
 
 # Run all pre-commit hooks on all files
 [group('lint')]


### PR DESCRIPTION
Corrects a typo in the `justfile`'s `update-pre` recipe and updates several pre-commit hooks to their latest versions.