### PR TITLE
Fix SonarQube findings: workflow permissions and uv run locking

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,4 @@
 name: Docs
-permissions:
-  contents: read
 concurrency:
   group: pages
   cancel-in-progress: true
@@ -12,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -26,6 +26,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pages: write
       id-token: write
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       - name: Build docs
-        run: uv run --group docs sphinx-build -b html docs docs/_build/html
+        run: uv run --locked --group docs sphinx-build -b html docs docs/_build/html
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/_build/html
@@ -26,7 +26,6 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pages: write
       id-token: write
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,11 +7,11 @@ on:
     branches:
       - main
   workflow_dispatch:
-permissions:
-  contents: read
 jobs:
   build-docs-html:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -25,6 +25,8 @@ jobs:
           path: "./docs/_build/html/"
   build-docs-pdf:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -63,6 +65,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     permissions:
+      contents: read
       pages: write
       id-token: write
     steps:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -65,7 +65,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     permissions:
-      contents: read
       pages: write
       id-token: write
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         run: just test ${{ (github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest') && '--cov=sphinxcontrib_bibtex_urn --cov-report=html --cov-report=xml' || '' }}
       - name: Generate coverage badge
         if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
-        run: uv run --group dev --group github genbadge coverage -i coverage.xml -o htmlcov/coverage.svg
+        run: uv run --locked --group dev --group github genbadge coverage -i coverage.xml -o htmlcov/coverage.svg
       - name: Upload coverage report
         if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -56,8 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-code
     if: always()
-    permissions:
-      contents: read
+    permissions: {}
     steps:
       - name: Check test matrix results
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,4 @@
 name: Test
-permissions:
-  contents: read
 on:
   pull_request:
   push:
@@ -11,6 +9,8 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -19,10 +19,14 @@ jobs:
       - uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
       - uses: j178/prek-action@cbc2f23eb5539cf20d82d1aabd0d0ecbcc56f4e3 # v2
   get-python-versions:
+    permissions:
+      contents: read
     uses: ./.github/workflows/get-python-versions.yml
   test-code:
     needs: get-python-versions
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -52,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: test-code
     if: always()
+    permissions:
+      contents: read
     steps:
       - name: Check test matrix results
         run: |


### PR DESCRIPTION
## Fixes
- [`githubactions:S8264` docs.yml:3](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=nikosavola_sphinxcontrib-bibtex-urn&open=AZ_r_CRoWmL3NC2yOJj6) -- moved `permissions: contents: read` from workflow root into `build` job, merged into `deploy` job's existing permissions
- [`githubactions:S8264` pages.yml:11](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=nikosavola_sphinxcontrib-bibtex-urn&open=AZ_r_CQzWmL3NC2yOJj5) -- moved `permissions: contents: read` from workflow root into `build-docs-html` and `build-docs-pdf` jobs, merged into `deploy-docs` job's existing permissions
- [`githubactions:S8264` test.yml:3](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=nikosavola_sphinxcontrib-bibtex-urn&open=AZ_r_CNxWmL3NC2yOJj2) -- moved `permissions: contents: read` from workflow root into `pre-commit`, `get-python-versions`, `test-code`, and `test-code-result` jobs
- [`githubactions:S8541`](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=nikosavola_sphinxcontrib-bibtex-urn&open=AZ_r_CRoWmL3NC2yOJj7) / [`S8544`](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=nikosavola_sphinxcontrib-bibtex-urn&open=AZ_r_CRoWmL3NC2yOJj8) docs.yml:21 -- added `--locked` to `uv run --group docs sphinx-build`
- [`githubactions:S8541`](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=nikosavola_sphinxcontrib-bibtex-urn&open=AZ_r_CNxWmL3NC2yOJj3) / [`S8544`](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=nikosavola_sphinxcontrib-bibtex-urn&open=AZ_r_CNxWmL3NC2yOJj4) test.yml:44 -- added `--locked` to `uv run --group dev --group github genbadge`

`--no-build` was not added to either `uv run` command: the local editable package (`sphinxcontrib-bibtex-urn`) has no binary distribution and fails to install under `--no-build`. Verified `--locked` alone (dropping `--no-build`) still runs both commands successfully.

## Not changed (believed false positives)
- [`python:S5332` styles.py:41](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=nikosavola_sphinxcontrib-bibtex-urn&open=AZ_r_CS8WmL3NC2yOJj9) / [:42](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=nikosavola_sphinxcontrib-bibtex-urn&open=AZ_r_CS8WmL3NC2yOJj-) -- `_RESOLVER_PREFIXES` intentionally includes http variants of resolvers for matching real-world URN URLs, not for making requests
- [`python:S5332` styles.py:72](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=nikosavola_sphinxcontrib-bibtex-urn&open=AZ_r_CS8WmL3NC2yOJj_) -- `stripped_lower.startswith(("http://", "https://"))` checks whether input is already a full URL, no outbound request made
- [`python:S5332` styles.py:120](https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&id=nikosavola_sphinxcontrib-bibtex-urn&open=AZ_r_CS8WmL3NC2yOJkA) -- `prefix.replace("https://", "http://")` generates the http-variant of a resolver prefix for comparison in `_is_redundant_url`, no outbound request made
- All four are literal strings used for matching/validating URLs, never for making a request; rewriting them would break matching against real-world URN URLs historically served over plain http